### PR TITLE
Fix overflow in self-test

### DIFF
--- a/MPU9250BasicAHRS.ino
+++ b/MPU9250BasicAHRS.ino
@@ -919,7 +919,7 @@ void MPU9250SelfTest(float * destination) // Should return percent deviation fro
 {
    uint8_t rawData[6] = {0, 0, 0, 0, 0, 0};
    uint8_t selfTest[6];
-   int16_t gAvg[3], aAvg[3], aSTAvg[3], gSTAvg[3];
+   int32_t gAvg[3] = {0}, aAvg[3] = {0}, aSTAvg[3] = {0}, gSTAvg[3] = {0};
    float factoryTrim[6];
    uint8_t FS = 0;
    
@@ -994,8 +994,8 @@ void MPU9250SelfTest(float * destination) // Should return percent deviation fro
  // Report results as a ratio of (STR - FT)/FT; the change from Factory Trim of the Self-Test Response
  // To get percent, must multiply by 100
    for (int i = 0; i < 3; i++) {
-     destination[i]   = 100.0*((float)(aSTAvg[i] - aAvg[i]))/factoryTrim[i];   // Report percent differences
-     destination[i+3] = 100.0*((float)(gSTAvg[i] - gAvg[i]))/factoryTrim[i+3]; // Report percent differences
+     destination[i]   = 100.0*((float)(aSTAvg[i] - aAvg[i]))/factoryTrim[i] - 100.0;   // Report percent differences
+     destination[i+3] = 100.0*((float)(gSTAvg[i] - gAvg[i]))/factoryTrim[i+3] - 100.0; // Report percent differences
    }
    
 }


### PR DESCRIPTION
I don't have the arduino IDE atm so I can't really test this code
exactly like this, but on a different platform it works.
