### PR TITLE
Make interrupt state var volatile

### DIFF
--- a/MPU9250_MS5637_AHRS_t3.ino
+++ b/MPU9250_MS5637_AHRS_t3.ino
@@ -254,7 +254,7 @@ float aRes, gRes, mRes;      // scale resolutions per LSB for the sensors
   
 // Pin definitions
 int intPin = 8;  
-bool newData = false;
+volatile bool newData = false;
 bool newMagData = false;
 
 int myLed = 13;


### PR DESCRIPTION
All objects referenced by ISRs should be volatile, forcing the compiler to not assume the value hasn't changed spontaneously.